### PR TITLE
Add uuid for player on leaderboard update request

### DIFF
--- a/noteblock-api/src/main/java/gg/makera/noteblock/api/NoteblockAPI.java
+++ b/noteblock-api/src/main/java/gg/makera/noteblock/api/NoteblockAPI.java
@@ -6,6 +6,7 @@ import gg.makera.noteblock.api.response.ServerInfoResponse;
 import gg.makera.noteblock.api.response.UserInfoResponse;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 public interface NoteblockAPI extends AutoCloseable {
@@ -19,6 +20,7 @@ public interface NoteblockAPI extends AutoCloseable {
 
     CompletableFuture<LeaderboardUpdateResponse> updateLeaderboard(int serverId,
                                                                    @NotNull String leaderboardId,
+                                                                   @NotNull UUID uuid,
                                                                    @NotNull String playerName,
                                                                    double value);
 

--- a/noteblock-api/src/main/java/gg/makera/noteblock/api/NoteblockAPIImpl.java
+++ b/noteblock-api/src/main/java/gg/makera/noteblock/api/NoteblockAPIImpl.java
@@ -13,6 +13,7 @@ import gg.makera.noteblock.api.transport.ResponseData;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 public final class NoteblockAPIImpl implements NoteblockAPI {
@@ -43,9 +44,10 @@ public final class NoteblockAPIImpl implements NoteblockAPI {
     @Override
     public CompletableFuture<LeaderboardUpdateResponse> updateLeaderboard(int serverId,
                                                                           @NotNull String leaderboardId,
+                                                                          @NotNull UUID uuid,
                                                                           @NotNull String playerName,
                                                                           double value) {
-        return request(LeaderboardUpdateResponse.class, new LeaderboardUpdateRequest(serverId, leaderboardId, playerName, value));
+        return request(LeaderboardUpdateResponse.class, new LeaderboardUpdateRequest(serverId, leaderboardId, uuid, playerName, value));
     }
 
     @Override

--- a/noteblock-api/src/main/java/gg/makera/noteblock/api/request/LeaderboardUpdateRequest.java
+++ b/noteblock-api/src/main/java/gg/makera/noteblock/api/request/LeaderboardUpdateRequest.java
@@ -3,6 +3,7 @@ package gg.makera.noteblock.api.request;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Map;
+import java.util.UUID;
 
 public final class LeaderboardUpdateRequest implements NoteblockRequest {
 
@@ -11,12 +12,18 @@ public final class LeaderboardUpdateRequest implements NoteblockRequest {
     private final int serverId;
     private final String leaderboardId;
     private final String playerName;
+    private final UUID uuid;
     private final double value;
 
-    public LeaderboardUpdateRequest(int serverId, @NotNull String leaderboardId, @NotNull String playerName, double value) {
+    public LeaderboardUpdateRequest(int serverId,
+                                    @NotNull String leaderboardId,
+                                    @NotNull UUID uuid,
+                                    @NotNull String playerName,
+                                    double value) {
         this.serverId = serverId;
         this.leaderboardId = leaderboardId;
         this.playerName = playerName;
+        this.uuid = uuid;
         this.value = value;
     }
 
@@ -29,7 +36,8 @@ public final class LeaderboardUpdateRequest implements NoteblockRequest {
     public Map<String, Object> getBody() {
         return Map.of(
                 "player_name", playerName,
-                "value", value
+                "value", value,
+                "uuid", uuid
         );
     }
 }

--- a/noteblock-api/src/main/java/gg/makera/noteblock/api/request/LeaderboardUpdateRequest.java
+++ b/noteblock-api/src/main/java/gg/makera/noteblock/api/request/LeaderboardUpdateRequest.java
@@ -35,9 +35,9 @@ public final class LeaderboardUpdateRequest implements NoteblockRequest {
     @Override
     public Map<String, Object> getBody() {
         return Map.of(
+                "uuid", uuid,
                 "player_name", playerName,
-                "value", value,
-                "uuid", uuid
+                "value", value
         );
     }
 }


### PR DESCRIPTION
This pull request keeps the Java API implementation up-to-date with the Backend, since I've added UUIDs for leaderboard entries to:
1. Make sure names are updated when they're changed in player's Minecraft account
2. Better handle for duplications